### PR TITLE
Make transparency possibly cross-platform

### DIFF
--- a/DialogForm.cs
+++ b/DialogForm.cs
@@ -88,8 +88,6 @@ namespace FuckingClippy
             form.ShowInTaskbar = false;
             form.FormBorderStyle = FormBorderStyle.None;
             form.StartPosition = FormStartPosition.Manual;
-            form.TransparencyKey = Color.Purple;
-            form.BackColor = Color.Purple;
             form.ClientSize =
                 new Size(pClientSize.Width, pClientSize.Height + 15);
             form.Location =
@@ -141,7 +139,7 @@ namespace FuckingClippy
         }
     }
 
-    class DialogForm : Form
+    class DialogForm : TransparentForm
     {
         internal DialogForm()
         {

--- a/FuckingClippy.csproj
+++ b/FuckingClippy.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TransparentForm.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace FuckingClippy
 {
-    public partial class MainForm : Form
+    public partial class MainForm : TransparentForm
     {
         public MainForm()
         {
@@ -27,11 +27,6 @@ namespace FuckingClippy
                 new Point(CurrentScreen.WorkingArea.Width - (Width + 30),
                 CurrentScreen.WorkingArea.Height - (Height + 30));
 
-            // Make the form transparent
-            // NOTE: BackColor = Color.Transparent; will not work.
-            TransparencyKey = Color.Purple;
-            BackColor = Color.Purple;
-            
             picCharacter.Image = Animation.GetIdle();
 
             TopMost = true; // Only hell now. :-)

--- a/TransparentForm.cs
+++ b/TransparentForm.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace FuckingClippy
+{
+	public class TransparentForm : Form
+	{
+		public TransparentForm ()
+		{
+			SetStyle(ControlStyles.SupportsTransparentBackColor, true);
+			BackColor = Color.Transparent;
+		}
+
+		protected override void OnPaintBackground(PaintEventArgs e)
+		{
+			// Empty on purpose
+		}
+	}
+}
+


### PR DESCRIPTION
By overriding the OnPaintBackground function, transparency is achievable
on Mono as well.

Also tested on Windows. Not sure about Linux.

Do mind that if platform differences occur, they could still be solved with
macros, all concealed in the TransparentForm class.
